### PR TITLE
Add Splash Page and login pages

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -13,3 +13,7 @@
  *= require_tree .
  *= require_self
  */
+
+a:hover {
+  text-decoration: underline;
+}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,12 +2,11 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable, :confirmable
 
   has_many :entities, dependent: :destroy, foreign_key: 'author_id'
-  has_many :groups, dependent: :destroy, # foreign_key: 'author_id'
+  has_many :groups, dependent: :destroy # foreign_key: 'author_id'
 
-  # rubocop:disable Lint/Syntax
   validates :name, presence: true, length: { maximum: 50 }
   validates :email, presence: true, uniqueness: true
   validates :password, presence: true

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,4 +1,4 @@
-<%= stylesheet_link_tag "devise" %>
+<%#= stylesheet_link_tag "devise" %>
 
 <div class="devise-login">
   <h2>Log in</h2>

--- a/app/views/devise/sessions/splash.html.erb
+++ b/app/views/devise/sessions/splash.html.erb
@@ -1,6 +1,6 @@
 <div class="splash flex flex-col justify-center items-center h-screen p-4">
   <h1 class="splash-heading text-3xl font-bold mt-auto">
-    Budgget App
+    Budget App
   </h1>
 
   <div class="splash-buttons flex flex-col justify-center items-center w-full mt-auto">

--- a/app/views/devise/sessions/splash.html.erb
+++ b/app/views/devise/sessions/splash.html.erb
@@ -1,0 +1,12 @@
+<div class="splash flex flex-col justify-center items-center h-screen p-4">
+  <h1 class="splash-heading text-3xl font-bold mt-auto">
+    Budgget App
+  </h1>
+
+  <div class="splash-buttons flex flex-col justify-center items-center w-full mt-auto">
+    <%= link_to "LOG IN", new_user_session_path,
+      class: "bg-[#3778c2] text-white w-full text-center
+              py-3 mb-1" %>
+    <%= link_to "SIGN UP", new_user_registration_path, class: "text-gray-600" %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,12 +6,14 @@ Rails.application.routes.draw do
   # root "articles#index"
 
   devise_scope :user do
-    # authenticated :user do
-    #   root to: 'devise/sessions#splash', as: :authenticated_root
-    # end
+    authenticated :user do
+      root to: 'devise/sessions#splash', as: :authenticated_root
+    end
 
     unauthenticated :user do
       root to: 'devise/sessions#splash', as: :unauthenticated_root
     end
   end
+
+  root 'groups#index'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,10 @@ Rails.application.routes.draw do
   # root "articles#index"
 
   devise_scope :user do
+    # authenticated :user do
+    #   root to: 'devise/sessions#splash', as: :authenticated_root
+    # end
+
     unauthenticated :user do
       root to: 'devise/sessions#splash', as: :unauthenticated_root
     end


### PR DESCRIPTION
## Hi

## The following features was executed in this PR;

- Splash screen
  - A simple page with the name of your app (yes, you need to choose one), and links to the sign up and log in pages.

- Sign up and log in pages
  - The user should be able to register in the app with full name, email and password (all mandatory).
  - The user can log into the app using email and password.
  - If the user is not logged in, they can't access pages that require the user to be logged in (all the pages described below).